### PR TITLE
Added functionality to pass in github auth_token

### DIFF
--- a/R/cluster.R
+++ b/R/cluster.R
@@ -85,7 +85,7 @@ generateClusterConfig <- function(fileName, ...){
       rPackages = list(
         cran = vector(),
         github = vector(),
-        authToken = NULL
+        githubAuthToken = NULL
       )
     )
 
@@ -141,11 +141,11 @@ makeCluster <- function(clusterSetting = "cluster_settings.json", fullName = FAL
   }
   
   environmentSettings <- NULL
-  if(!is.null(pool$rPackages) && !is.null(pool$rPackages$authToken)){
-    if(length(pool$rPackages$authToken) == 1) {
-      environmentSettings <- list(list(name = "GITHUB_PAT", value = pool$rPackages$authToken))
+  if(!is.null(pool$rPackages) && !is.null(pool$rPackages$githubAuthToken)){
+    if(length(pool$rPackages$githubAuthToken) == 1) {
+      environmentSettings <- list(list(name = "GITHUB_PAT", value = pool$rPackages$githubAuthToken))
     } else {
-      stop("authToken length is not equal to 1")
+      stop("githubAuthToken length is not equal to 1")
     }
   }
 

--- a/R/cluster.R
+++ b/R/cluster.R
@@ -85,7 +85,7 @@ generateClusterConfig <- function(fileName, ...){
       rPackages = list(
         cran = vector(),
         github = vector(),
-        githubAuthToken = NULL
+        githubAuthenticationToken = NULL
       )
     )
 
@@ -141,11 +141,11 @@ makeCluster <- function(clusterSetting = "cluster_settings.json", fullName = FAL
   }
   
   environmentSettings <- NULL
-  if(!is.null(pool$rPackages) && !is.null(pool$rPackages$githubAuthToken)){
-    if(length(pool$rPackages$githubAuthToken) == 1) {
-      environmentSettings <- list(list(name = "GITHUB_PAT", value = pool$rPackages$githubAuthToken))
+  if(!is.null(pool$rPackages) && !is.null(pool$rPackages$githubAuthenticationToken)){
+    if(length(pool$rPackages$githubAuthenticationToken) == 1) {
+      environmentSettings <- list(list(name = "GITHUB_PAT", value = pool$rPackages$githubAuthenticationToken))
     } else {
-      stop("githubAuthToken length is not equal to 1")
+      stop("githubAuthenticationToken length is not equal to 1")
     }
   }
 

--- a/R/cluster.R
+++ b/R/cluster.R
@@ -84,7 +84,8 @@ generateClusterConfig <- function(fileName, ...){
       ),
       rPackages = list(
         cran = vector(),
-        github = vector()
+        github = vector(),
+        authToken = NULL
       )
     )
 
@@ -138,10 +139,20 @@ makeCluster <- function(clusterSetting = "cluster_settings.json", fullName = FAL
       packages <- paste0(packages, ";", getGithubInstallationCommand(pool$rPackages$github))
     }
   }
+  
+  environmentSettings <- NULL
+  if(!is.null(pool$rPackages) && !is.null(pool$rPackages$authToken)){
+    if(length(pool$rPackages$authToken) == 1) {
+      environmentSettings <- list(list(name = "GITHUB_PAT", value = pool$rPackages$authToken))
+    } else {
+      stop("authToken length is not equal to 1")
+    }
+  }
 
   response <- .addPool(
     pool = pool$pool,
     packages = packages,
+    environmentSettings = environmentSettings,
     resourceFiles = resourceFiles)
 
   pool <- getPool(pool$pool$name)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -155,7 +155,8 @@
   return(response)
 }
 
-.addPool <- function(pool, packages, resourceFiles){
+.addPool <- function(pool, packages, environmentSettings, resourceFiles){
+  
   commands <- c("export PATH=/anaconda/envs/py35/bin:$PATH",
                 "env PATH=$PATH pip install --no-dependencies blobxfer")
 
@@ -174,6 +175,10 @@
     waitForSuccess = TRUE
   )
 
+  if(!is.null(environmentSettings)){
+    startTask$environmentSettings = environmentSettings
+  }
+  
   if(length(resourceFiles) > 0){
     startTask$resourceFiles = resourceFiles
   }


### PR DESCRIPTION
Added install_github auth_token as an environment variable. This allows one to install private github repositories on the Azure cluster (I needed this). I would have passed it into the install_github function but there is a bug that does not pass the auth_token to additional remotes which I needed ([#87 under remotes](https://github.com/r-lib/remotes/issues/87)).