### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,5 @@ Depends:
     rAzureBatch (>= 0.4.0)
 Suggests:
     testthat, caret, plyr, lintr
+Remotes: Azure/rAzureBatch
 RoxygenNote: 6.0.1


### PR DESCRIPTION
At the moment, rAzureBatch is not available on CRAN, so it can be accessible from github repo.
Vignette https://github.com/hadley/devtools/blob/master/vignettes/dependencies.Rmd
Example https://github.com/hadley/devtools/blob/master/DESCRIPTION