### PR TITLE
treat warnings as failures and fail the creation of the cluster

### DIFF
--- a/R/utility.R
+++ b/R/utility.R
@@ -21,11 +21,11 @@ getPoolPackageInstallationCommand <- function(type, packages) {
 
   if (type == "cran") {
     script <-
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'install.packages(args[1])\' %s"
+      "Rscript -e \'args <- commandArgs(TRUE)\' -e \'options(warn=2)\' -e \'install.packages(args[1])\' %s"
   }
   else if (type == "github") {
     script <-
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'devtools::install_github(args[1])\' %s"
+      "Rscript -e \'args <- commandArgs(TRUE)\' -e \'options(warn=2)\' -e \'devtools::install_github(args[1])\' %s"
   }
   else {
     stop("Using an incorrect package source")

--- a/R/utility.R
+++ b/R/utility.R
@@ -21,11 +21,11 @@ getPoolPackageInstallationCommand <- function(type, packages) {
 
   if (type == "cran") {
     script <-
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e \'install.packages(args[1])\' %s"
+      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'install.packages(args[1])\' %s"
   }
   else if (type == "github") {
     script <-
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e \'devtools::install_github(args[1])\' %s"
+      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'devtools::install_github(args[1])\' %s"
   }
   else {
     stop("Using an incorrect package source")
@@ -44,7 +44,7 @@ linuxWrapCommands <- function(commands = c()) {
     sprintf("/bin/bash -c \"set -e; set -o pipefail; %s wait\"",
             paste0(paste(
               commands, sep = " ", collapse = "; "
-            ), ";"))
+            ), " ;"))
 
   commandLine
 }

--- a/R/utility.R
+++ b/R/utility.R
@@ -44,7 +44,7 @@ linuxWrapCommands <- function(commands = c()) {
     sprintf("/bin/bash -c \"set -e; set -o pipefail; %s wait\"",
             paste0(paste(
               commands, sep = " ", collapse = "; "
-            ), " ;"))
+            ), ";"))
 
   commandLine
 }

--- a/tests/testthat/test-package-installation.R
+++ b/tests/testthat/test-package-installation.R
@@ -38,8 +38,10 @@ test_that("successfully create github pool package command line", {
 
   expected <-
     c(
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'devtools::install_github(args[1])\' Azure/doAzureParallel",
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'devtools::install_github(args[1])\' Azure/rAzureBatch"
+      paste0("Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' ",
+        "-e \'devtools::install_github(args[1])\' Azure/doAzureParallel"),
+      paste0("Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' ",
+        "-e \'devtools::install_github(args[1])\' Azure/rAzureBatch")
     )
 
   expect_equal(poolInstallation, expected)

--- a/tests/testthat/test-package-installation.R
+++ b/tests/testthat/test-package-installation.R
@@ -23,9 +23,9 @@ test_that("successfully create cran pool package command line", {
   expect_equal(length(poolInstallation), 3)
   expected <-
     c(
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e \'install.packages(args[1])\' hts",
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e \'install.packages(args[1])\' lubridate",
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e \'install.packages(args[1])\' tidyr"
+      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'install.packages(args[1])\' hts",
+      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'install.packages(args[1])\' lubridate",
+      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'install.packages(args[1])\' tidyr"
     )
 
   expect_equal(poolInstallation, expected)
@@ -38,8 +38,8 @@ test_that("successfully create github pool package command line", {
 
   expected <-
     c(
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e \'devtools::install_github(args[1])\' Azure/doAzureParallel",
-      "Rscript -e \'args <- commandArgs(TRUE)\' -e \'devtools::install_github(args[1])\' Azure/rAzureBatch"
+      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'devtools::install_github(args[1])\' Azure/doAzureParallel",
+      "Rscript -e \'args <- commandArgs(TRUE)\' -e 'options(warn=2)' -e \'devtools::install_github(args[1])\' Azure/rAzureBatch"
     )
 
   expect_equal(poolInstallation, expected)


### PR DESCRIPTION
Fix for #81

This change updates all warnings to show up as errors. Currently the default behavior for Rscript is to treat all warnings as noise and ignores them returning an exit code of 0.