### PR TITLE
Removing rAzureBatch::deleteJob

### DIFF
--- a/R/doAzureParallel.R
+++ b/R/doAzureParallel.R
@@ -482,8 +482,6 @@ setVerbose <- function(value = FALSE) {
       cat(sprintf("Number of errors: %i", numberOfFailedTasks),
           fill = TRUE)
 
-      rAzureBatch::deleteJob(id)
-
       if (identical(obj$errorHandling, "stop") &&
           !is.null(errorValue)) {
         msg <- sprintf("task %d failed - '%s'",


### PR DESCRIPTION
Please, delete this pull request if I'm wrong and there is a real reason to delete the previous job. 
In my humble opinion, it is harder to debug R code execution on the node side after the jobs were deleted.
I still have not found the way to do this.