### PR TITLE
Fixed worker and merger scripts

### DIFF
--- a/R/doAzureParallel.R
+++ b/R/doAzureParallel.R
@@ -185,7 +185,6 @@ setHttpTraffic <- function(value = FALSE) {
   }
 
   pkgName <- if (exists("packageName", mode = "function"))
-
     packageName(envir)
   else
     NULL

--- a/R/doAzureParallel.R
+++ b/R/doAzureParallel.R
@@ -429,10 +429,10 @@ setHttpTraffic <- function(value = FALSE) {
   rAzureBatch::updateJob(id)
 
   if (enableCloudCombine) {
-    mergeTask <- paste0(id, "-merge")
+    mergeTaskId <- paste0(id, "-merge")
     .addTask(
       jobId = id,
-      taskId = mergeTask,
+      taskId = mergeTaskId,
       rCommand = sprintf(
         "Rscript --vanilla --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/merger.R %s %s %s > $AZ_BATCH_TASK_ID.txt",
         length(tasks),

--- a/R/doAzureParallel.R
+++ b/R/doAzureParallel.R
@@ -413,16 +413,10 @@ setHttpTraffic <- function(value = FALSE) {
     taskId <- paste0(id, "-task", i)
 
     .addTask(
-      id,
+      jobId = id,
       taskId = taskId,
       rCommand =  sprintf(
-        "Rscript --vanilla --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/worker.R %s %s %s %s > %s.txt",
-        "$AZ_BATCH_JOB_PREP_WORKING_DIR",
-        "$AZ_BATCH_TASK_WORKING_DIR",
-        jobFileName,
-        paste0(taskId, ".rds"),
-        taskId
-      ),
+        "Rscript --vanilla --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/worker.R > $AZ_BATCH_TASK_ID.txt"),
       args = argsList[startIndex:endIndex],
       envir = .doAzureBatchGlobals,
       packages = obj$packages,
@@ -435,17 +429,15 @@ setHttpTraffic <- function(value = FALSE) {
   rAzureBatch::updateJob(id)
 
   if (enableCloudCombine) {
+    mergeTask <- paste0(id, "-merge")
     .addTask(
-      id,
-      taskId = paste0(id, "-merge"),
+      jobId = id,
+      taskId = mergeTask,
       rCommand = sprintf(
-        "Rscript --vanilla --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/merger.R %s %s %s %s %s > %s.txt",
-        "$AZ_BATCH_JOB_PREP_WORKING_DIR",
-        "$AZ_BATCH_TASK_WORKING_DIR",
-        id,
+        "Rscript --vanilla --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/merger.R %s %s %s > $AZ_BATCH_TASK_ID.txt",
         length(tasks),
-        ntasks,
-        paste0(id, "-merge")
+        chunkSize,
+        as.character(obj$errorHandling)
       ),
       envir = .doAzureBatchGlobals,
       packages = obj$packages,
@@ -460,61 +452,67 @@ setHttpTraffic <- function(value = FALSE) {
       waitForJobPreparation(id, data$poolId)
     }
 
-    waitForTasksToComplete(id, jobTimeout)
+    tryCatch({
+        waitForTasksToComplete(id, jobTimeout, obj$errorHandling)
 
-    if (typeof(cloudCombine) == "list" && enableCloudCombine) {
-      tempFile <- tempfile("doAzureParallel", fileext = ".rds")
+        if (typeof(cloudCombine) == "list" && enableCloudCombine) {
+          tempFile <- tempfile("doAzureParallel", fileext = ".rds")
 
-      response <-
-        rAzureBatch::downloadBlob(
-          id,
-          paste0("result/", id, "-merge-result.rds"),
-          sasToken = sasToken,
-          accountName = storageCredentials$name,
-          downloadPath = tempFile,
-          overwrite = TRUE
-        )
+          response <-
+            rAzureBatch::downloadBlob(
+              id,
+              paste0("result/", id, "-merge-result.rds"),
+              sasToken = sasToken,
+              accountName = storageCredentials$name,
+              downloadPath = tempFile,
+              overwrite = TRUE
+            )
 
-      results <- readRDS(tempFile)
+          results <- readRDS(tempFile)
 
-      failTasks <- sapply(results, .isError)
+          failTasks <- sapply(results, .isError)
 
-      numberOfFailedTasks <- sum(unlist(failTasks))
+          numberOfFailedTasks <- sum(unlist(failTasks))
 
-      if (numberOfFailedTasks > 0) {
-        .createErrorViewerPane(id, failTasks)
-      }
+          if (numberOfFailedTasks > 0) {
+            .createErrorViewerPane(id, failTasks)
+          }
 
-      accumulator <- foreach::makeAccum(it)
+          accumulator <- foreach::makeAccum(it)
 
-      tryCatch(
-        accumulator(results, seq(along = results)),
-        error = function(e) {
-          cat("error calling combine function:\n")
-          print(e)
+          tryCatch(
+            accumulator(results, seq(along = results)),
+            error = function(e) {
+              cat("error calling combine function:\n")
+              print(e)
+            }
+          )
+
+          # check for errors
+          errorValue <- foreach::getErrorValue(it)
+          errorIndex <- foreach::getErrorIndex(it)
+
+          cat(sprintf("Number of errors: %i", numberOfFailedTasks),
+              fill = TRUE)
+
+          rAzureBatch::deleteJob(id)
+
+          if (identical(obj$errorHandling, "stop") &&
+              !is.null(errorValue)) {
+            msg <- sprintf("task %d failed - '%s'",
+                           errorIndex,
+                           conditionMessage(errorValue))
+            stop(simpleError(msg, call = expr))
+          }
+          else {
+            foreach::getResult(it)
+          }
         }
-      )
-
-      # check for errors
-      errorValue <- foreach::getErrorValue(it)
-      errorIndex <- foreach::getErrorIndex(it)
-
-      cat(sprintf("Number of errors: %i", numberOfFailedTasks),
-          fill = TRUE)
-
-      rAzureBatch::deleteJob(id)
-
-      if (identical(obj$errorHandling, "stop") &&
-          !is.null(errorValue)) {
-        msg <- sprintf("task %d failed - '%s'",
-                       errorIndex,
-                       conditionMessage(errorValue))
-        stop(simpleError(msg, call = expr))
+      },
+      error = function(ex){
+        message(ex)
       }
-      else {
-        foreach::getResult(it)
-      }
-    }
+    )
   }
   else{
     print(

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -29,8 +29,16 @@
   resourceFiles <-
     list(rAzureBatch::createResourceFile(url = envFileUrl, fileName = envFile))
 
+  exitConditions <- NULL
   if (!is.null(args$dependsOn)) {
     dependsOn <- list(taskIds = dependsOn)
+  }
+  else {
+    exitConditions <- list(
+      default = list(
+        dependencyAction = "satisfy"
+      )
+    )
   }
 
   resultFile <- paste0(taskId, "-result", ".rds")
@@ -122,7 +130,8 @@
     resourceFiles = resourceFiles,
     commandLine = commands,
     dependsOn = dependsOn,
-    outputFiles = outputFiles
+    outputFiles = outputFiles,
+    exitConditions = exitConditions
   )
 }
 

--- a/R/utility.R
+++ b/R/utility.R
@@ -257,7 +257,8 @@ getJobResult <- function(jobId = "", ...) {
 
   if (!is.null(args$container)) {
     results <-
-      rAzureBatch::downloadBlob(args$container, paste0("result/", jobId, "-merge-result.rds"))
+      rAzureBatch::downloadBlob(args$container,
+                                paste0("result/", jobId, "-merge-result.rds"))
   }
   else{
     results <-
@@ -437,58 +438,25 @@ createOutputFile <- function(filePattern, url) {
   output
 }
 
+
 #' Wait for current tasks to complete
 #'
 #' @export
-waitForTasksToComplete <- function(jobId, timeout) {
-  cat("Waiting for tasks to complete. . .", fill = TRUE)
+waitForTasksToComplete <-
+  function(jobId, timeout, errorHandling = "stop") {
+    cat("Waiting for tasks to complete. . .", fill = TRUE)
 
-  numOfTasks <- 0
-  currentTasks <- rAzureBatch::listTask(jobId)
-
-  if (is.null(currentTasks$value)) {
-    stop(paste0("Error: ", currentTasks$message$value))
-    return()
-  }
-
-  numOfTasks <- numOfTasks + length(currentTasks$value)
-
-  # Getting the total count of tasks for progress bar
-  repeat {
-    if (is.null(currentTasks$odata.nextLink)) {
-      break
-    }
-
-    skipTokenParameter <-
-      strsplit(currentTasks$odata.nextLink, "&")[[1]][2]
-
-    skipTokenValue <-
-      substr(skipTokenParameter,
-             nchar("$skiptoken=") + 1,
-             nchar(skipTokenParameter))
-
-    currentTasks <-
-      rAzureBatch::listTask(jobId, skipToken = URLdecode(skipTokenValue))
-    numOfTasks <- numOfTasks + length(currentTasks$value)
-  }
-
-  pb <- txtProgressBar(min = 0, max = numOfTasks, style = 3)
-
-  timeToTimeout <- Sys.time() + timeout
-
-  while (Sys.time() < timeToTimeout) {
-    count <- 0
+    totalTasks <- 0
     currentTasks <- rAzureBatch::listTask(jobId)
 
-    taskStates <-
-      lapply(currentTasks$value, function(x)
-        x$state != "completed")
-    for (i in 1:length(taskStates)) {
-      if (taskStates[[i]] == FALSE) {
-        count <- count + 1
-      }
+    if (is.null(currentTasks$value)) {
+      stop(paste0("Error: ", currentTasks$message$value))
+      return()
     }
 
+    totalTasks <- totalTasks + length(currentTasks$value)
+
+    # Getting the total count of tasks for progress bar
     repeat {
       if (is.null(currentTasks$odata.nextLink)) {
         break
@@ -505,29 +473,72 @@ waitForTasksToComplete <- function(jobId, timeout) {
       currentTasks <-
         rAzureBatch::listTask(jobId, skipToken = URLdecode(skipTokenValue))
 
-      taskStates <-
-        lapply(currentTasks$value, function(x)
-          x$state != "completed")
+      totalTasks <- totalTasks + length(currentTasks$value)
+    }
 
-      for (i in 1:length(taskStates)) {
-        if (taskStates[[i]] == FALSE) {
-          count <- count + 1
+    pb <- txtProgressBar(min = 0, max = totalTasks, style = 3)
+    timeToTimeout <- Sys.time() + timeout
+
+    repeat {
+      taskCounts <- rAzureBatch::getJobTaskCounts(jobId)
+
+      setTxtProgressBar(pb, taskCounts$completed)
+
+
+      if (taskCounts$failed > 0 &&
+          errorHandling == "stop" &&
+          taskCounts$validationStatus == "Validated") {
+        cat("\n")
+
+        filter <- "state eq 'completed' and executionInfo/exitCode ne 0"
+        select <- "id, executionInfo"
+
+        failedTasks <-
+          rAzureBatch::listTask(jobId, filter = filter, select = select)
+
+        tasksFailureWarningLabel <-
+          sprintf("There are currently %i tasks failed while running the job:\n", taskCounts$failed)
+
+        for (i in 1:length(failedTasks$value)) {
+          if (failedTasks$value[[i]]$executionInfo$result == "Failure") {
+            tasksFailureWarningLabel <-
+              paste0(tasksFailureWarningLabel,
+                     sprintf("%s\n", failedTasks$value[[i]]$id))
+          }
         }
+
+        warning(sprintf(tasksFailureWarningLabel,
+                        taskCounts$failed))
+
+        response <- rAzureBatch::terminateJob(jobId)
+        httr::stop_for_status(response)
+
+        stop(sprintf(
+          paste("Errors have occurred while running the job '%s'.",
+                "Error handling is set to 'stop' and has proceeded to terminate the job.",
+                "The user will have to handle deleting the job.",
+                "If this is not the correct behavior, change the errorHandling property",
+                "in the foreach object. Use the 'getJobFile' function to obtain the logs.",
+                "For more information about getting job logs, follow this link:",
+                paste0("https://github.com/Azure/doAzureParallel/blob/master/docs/",
+                       "40-troubleshooting.md#viewing-files-directly-from-compute-node")),
+          jobId
+        ))
       }
+
+      if (Sys.time() > timeToTimeout) {
+        stop("A timeout has occurred when waiting for tasks to complete. ")
+      }
+
+      if (taskCounts$completed >= totalTasks &&
+          taskCounts$validationStatus == "Validated") {
+        cat("\n")
+        return(0)
+      }
+
+      Sys.sleep(10)
     }
-
-    setTxtProgressBar(pb, count)
-
-    if (all(taskStates == FALSE)) {
-      cat("\n")
-      return(0)
-    }
-
-    Sys.sleep(10)
   }
-
-  stop("A timeout has occurred when waiting for tasks to complete.")
-}
 
 waitForJobPreparation <- function(jobId, poolId) {
   cat("Job Preparation Status: Package(s) being installed")
@@ -556,11 +567,13 @@ waitForJobPreparation <- function(jobId, poolId) {
     # Verify that all the job preparation tasks are not failing
     if (all(FALSE %in% statuses)) {
       cat("\n")
-      stop(paste(
-        sprintf("Job '%s' unable to install packages.", jobId),
-        "Use the 'getJobFile' function to get more information about",
-        "job package installation."
-      ))
+      stop(
+        paste(
+          sprintf("Job '%s' unable to install packages.", jobId),
+          "Use the 'getJobFile' function to get more information about",
+          "job package installation."
+        )
+      )
     }
 
     cat(".")
@@ -574,6 +587,6 @@ getXmlValues <- function(xmlResponse, xmlPath) {
   xml2::xml_text(xml2::xml_find_all(xmlResponse, xmlPath))
 }
 
-areShallowEqual <- function(a, b){
+areShallowEqual <- function(a, b) {
   !is.null(a) && !is.null(b) && a == b
 }

--- a/R/utility.R
+++ b/R/utility.R
@@ -481,9 +481,7 @@ waitForTasksToComplete <-
 
     repeat {
       taskCounts <- rAzureBatch::getJobTaskCounts(jobId)
-
       setTxtProgressBar(pb, taskCounts$completed)
-
 
       validationFlag <-
         (taskCounts$validationStatus == "Validated" &&
@@ -537,7 +535,7 @@ waitForTasksToComplete <-
         stop(sprintf(paste("Timeout has occurred while waiting for tasks to complete.",
                    "Users will have to manually track the job '%s' and get the results.",
                    "Use the getJobResults function to obtain the results and getJobList for",
-                   "tracking job status. To change the timeout, user can set 'timeout' property in the",
+                   "tracking job status. To change the timeout, set 'timeout' property in the",
                    "foreach's options.azure.")),
              jobId)
       }

--- a/README.md
+++ b/README.md
@@ -220,8 +220,7 @@ results <- foreach(i = 1:number_of_iterations) %dopar% { ... }
 ### Error Handling
 The errorhandling option specifies how failed tasks should be evaluated. By default, the error handling is 'stop' to ensure users' can have reproducible results. If a combine function is assigned, it must be able to handle error objects.
 
-Types of Error Handling:
-Error Handling | Description
+Error Handling Type | Description
 --- | ---
 stop | The execution of the foreach will stop if an error occurs
 pass | The error object of the task is included the results

--- a/README.md
+++ b/README.md
@@ -217,6 +217,58 @@ results <- foreach(i = 1:number_of_iterations) %do% { ... }
 results <- foreach(i = 1:number_of_iterations) %dopar% { ... }
 ```
 
+### Error Handling
+The errorhandling option specifies how failed tasks should be evaluated. By default, the error handling is 'stop' to ensure users' can have reproducible results. If a combine function is assigned, it must be able to handle error objects.
+
+Types of Error Handling:
+Error Handling | Description
+--- | ---
+stop | The execution of the foreach will stop if an error occurs
+pass | The error object of the task is included the results
+remove | The result of a failed task will not be returned 
+
+```R 
+# Remove R error objects from the results
+res <- foreach::foreach(i = 1:4, .errorhandling = "remove") %dopar% {
+  if (i == 2 || i == 4) {
+    randomObject
+  }
+  
+  mean(1:3)
+}
+
+#> res
+#[[1]]
+#[1] 2
+#
+#[[2]]
+#[1] 2
+```
+
+```R 
+# Passing R error objects into the results 
+res <- foreach::foreach(i = 1:4, .errorhandling = "pass") %dopar% {
+  if (i == 2|| i == 4) {
+    randomObject
+  }
+  
+  sum(i, 1)
+}
+
+#> res
+#[[1]]
+#[1] 2
+#
+#[[2]]
+#<simpleError in eval(expr, envir, enclos): object 'randomObject' not found>
+#
+#[[3]]
+#[1] 4
+#
+#[[4]]
+#<simpleError in eval(expr, envir, enclos): object 'randomObject' not found>
+```
+
 ### Long-running Jobs + Job Management
 
 doAzureParallel also helps you manage your jobs so that you can run many jobs at once while managing it through a few simple methods.

--- a/inst/startup/install_github.R
+++ b/inst/startup/install_github.R
@@ -2,17 +2,30 @@
 args <- commandArgs(trailingOnly = TRUE)
 
 # Assumption: devtools is already installed based on Azure DSVM
+status <- tryCatch({
+  for (package in args) {
+    packageDirectory <- strsplit(package, "/")[[1]]
+    packageName <- packageDirectory[length(packageDirectory)]
 
-for (package in args) {
-  packageDirectory <- strsplit(package, "/")[[1]]
-  packageName <- packageDirectory[length(packageDirectory)]
-
-  if (!require(packageName, character.only = TRUE)) {
-    devtools::install_github(packageDirectory)
-    require(packageName, character.only = TRUE)
+    if (!require(package, character.only = TRUE)) {
+      devtools::install_github(packageDirectory)
+      require(package, character.only = TRUE)
+    }
   }
-}
+
+  return(0)
+},
+error = function(e) {
+  cat(sprintf(
+    "Error getting parent environment: %s\n",
+    conditionMessage(e)
+  ))
+
+  # Install packages doesn't return a non-exit code.
+  # Using '1' as the default non-exit code
+  return(1)
+})
 
 quit(save = "yes",
-     status = 0,
+     status = status,
      runLast = FALSE)

--- a/inst/startup/merger.R
+++ b/inst/startup/merger.R
@@ -1,64 +1,125 @@
 #!/usr/bin/Rscript
 args <- commandArgs(trailingOnly = TRUE)
+status <- 0
 
-# test if there is at least one argument: if not, return an error
-if (length(args) == 0) {
-  stop("At least one argument must be supplied (input file).n", call. = FALSE)
-} else if (length(args) == 1) {
-  # default output file
-  args[2] <- "out.txt"
+isError <- function(x) {
+  inherits(x, "simpleError") || inherits(x, "try-error")
 }
 
-batchJobPreparationDirectory <- args[1]
-batchTaskWorkingDirectory <- args[2]
-batchJobId <- args[3]
+getSimpleErrorMessage <- function(e) {
+  print(e$message)
+  e$message
+}
 
-n <- args[4]
-numOfTasks <- args[5]
+getSimpleErrorCall <- function(e) {
+  deparse(e$call)
+}
+
+batchTasksCount <- as.integer(args[1])
+chunkSize <- as.integer(args[2])
+errorHandling <- args[3]
+cat(chunkSize, fill = TRUE)
+cat(batchTasksCount, fill = TRUE)
+
+batchJobId <- Sys.getenv("AZ_BATCH_JOB_ID")
+batchJobPreparationDirectory <-
+  Sys.getenv("AZ_BATCH_JOB_PREP_WORKING_DIR")
+batchTaskWorkingDirectory <- Sys.getenv("AZ_BATCH_TASK_WORKING_DIR")
 
 azbatchenv <-
   readRDS(paste0(batchJobPreparationDirectory, "/", batchJobId, ".rds"))
 
+setwd(batchTaskWorkingDirectory)
+
 for (package in azbatchenv$packages) {
   library(package, character.only = TRUE)
 }
+
 parent.env(azbatchenv$exportenv) <- globalenv()
+sessionInfo()
 
 enableCloudCombine <- azbatchenv$enableCloudCombine
 cloudCombine <- azbatchenv$cloudCombine
 
 if (typeof(cloudCombine) == "list" && enableCloudCombine) {
-  results <- vector("list", numOfTasks)
+  results <- vector("list", batchTasksCount * chunkSize)
   count <- 1
-  tryCatch({
-    for (i in 1:n) {
-      taskResult <-
-        file.path(
-          batchTaskWorkingDirectory,
-          "result",
-          paste0(batchJobId, "-task", i, "-result.rds")
-        )
 
-      task <- readRDS(taskResult)
+  status <- tryCatch({
+    if (errorHandling == "remove" || errorHandling == "stop") {
+      files <- list.files(file.path(batchTaskWorkingDirectory,
+                                    "result"),
+                          full.names = TRUE)
 
-      for (t in 1:length(task)) {
-        results[count] <- task[t]
-        count <- count + 1
+      if (errorHandling == "stop" && length(files) != batchTasksCount) {
+        stop("Issues with file upload")
       }
+
+      results <- vector("list", length(files) * chunkSize)
+
+      for (i in 1:length(files)) {
+        task <- readRDS(files[i])
+
+        if (isError(task)) {
+          if (errorHandling == "stop") {
+            stop("Error found")
+          }
+          else {
+            next
+          }
+        }
+
+        for (t in 1:length(chunkSize)) {
+          results[count] <- task[t]
+          count <- count + 1
+        }
+      }
+
+      saveRDS(results, file = file.path(
+        batchTaskWorkingDirectory,
+        paste0(batchJobId, "-merge-result.rds")
+      ))
+    }
+    else if (errorHandling == "pass") {
+      for (i in 1:batchTasksCount) {
+        taskResult <-
+          file.path(
+            batchTaskWorkingDirectory,
+            "result",
+            paste0(batchJobId, "-task", i, "-result.rds")
+          )
+
+        if (file.exists(taskResult)) {
+          task <- readRDS(taskResult)
+          for (t in 1:length(chunkSize)) {
+            results[count] <- task[t]
+            count <- count + 1
+          }
+        }
+        else {
+          for (t in 1:length(chunkSize)) {
+            results[count] <- NA
+            count <- count + 1
+          }
+        }
+      }
+
+      saveRDS(results, file = file.path(
+        batchTaskWorkingDirectory,
+        paste0(batchJobId, "-merge-result.rds")
+      ))
     }
 
-    saveRDS(results, file = file.path(
-      batchTaskWorkingDirectory,
-      paste0(batchJobId, "-merge-result.rds")
-    ))
+    0
   },
   error = function(e) {
     print(e)
+    1
   })
 } else {
   # Work needs to be done for utilizing custom merge functions
 }
 
 quit(save = "yes",
-     status = 0,
+     status = status,
      runLast = FALSE)

--- a/inst/startup/merger.R
+++ b/inst/startup/merger.R
@@ -6,20 +6,9 @@ isError <- function(x) {
   inherits(x, "simpleError") || inherits(x, "try-error")
 }
 
-getSimpleErrorMessage <- function(e) {
-  print(e$message)
-  e$message
-}
-
-getSimpleErrorCall <- function(e) {
-  deparse(e$call)
-}
-
 batchTasksCount <- as.integer(args[1])
 chunkSize <- as.integer(args[2])
 errorHandling <- args[3]
-cat(chunkSize, fill = TRUE)
-cat(batchTasksCount, fill = TRUE)
 
 batchJobId <- Sys.getenv("AZ_BATCH_JOB_ID")
 batchJobPreparationDirectory <-
@@ -52,7 +41,11 @@ if (typeof(cloudCombine) == "list" && enableCloudCombine) {
                           full.names = TRUE)
 
       if (errorHandling == "stop" && length(files) != batchTasksCount) {
-        stop("Issues with file upload")
+        stop(paste("Error handling is set to 'stop' and there are missing results due to",
+                   "task failures. If this is not the correct behavior, change the errorHandling",
+                   "property to 'pass' or 'remove' in the foreach object.",
+                   "For more information on troubleshooting, check",
+                   "https://github.com/Azure/doAzureParallel/blob/master/docs/40-troubleshooting.md"))
       }
 
       results <- vector("list", length(files) * chunkSize)

--- a/inst/startup/worker.R
+++ b/inst/startup/worker.R
@@ -1,13 +1,6 @@
 #!/usr/bin/Rscript
 args <- commandArgs(trailingOnly = TRUE)
-
-# test if there is at least one argument: if not, return an error
-if (length(args) == 0) {
-  stop("At least one argument must be supplied (input file).n", call. = FALSE)
-} else if (length(args) == 1) {
-  # default output file
-  args[2] <- "out.txt"
-}
+workerErrorStatus <- 0
 
 getparentenv <- function(pkgname) {
   parenv <- NULL
@@ -55,10 +48,13 @@ getparentenv <- function(pkgname) {
     parenv
 }
 
-batchJobPreparationDirectory <- args[1]
-batchTaskWorkingDirectory <- args[2]
-batchJobEnvironment <- args[3]
-batchTaskEnvironment <- args[4]
+batchJobId <- Sys.getenv("AZ_BATCH_JOB_ID")
+batchTaskId <- Sys.getenv("AZ_BATCH_TASK_ID")
+batchJobPreparationDirectory <- Sys.getenv("AZ_BATCH_JOB_PREP_WORKING_DIR")
+batchTaskWorkingDirectory <- Sys.getenv("AZ_BATCH_TASK_WORKING_DIR")
+
+batchJobEnvironment <- paste0(batchJobId, ".rds")
+batchTaskEnvironment <- paste0(batchTaskId, ".rds")
 
 setwd(batchTaskWorkingDirectory)
 
@@ -87,11 +83,10 @@ result <- lapply(taskArgs, function(args) {
     eval(azbatchenv$expr, azbatchenv$exportenv)
   },
   error = function(e) {
-    print(e)
+    workerErrorStatus <<- 1
+    e
   })
 })
-
-fileResultName <- strsplit(batchTaskEnvironment, "[.]")[[1]][1]
 
 if (!is.null(azbatchenv$gather) && length(taskArgs) > 1) {
   result <- Reduce(azbatchenv$gather, result)
@@ -100,9 +95,10 @@ if (!is.null(azbatchenv$gather) && length(taskArgs) > 1) {
 saveRDS(result,
         file = file.path(
           batchTaskWorkingDirectory,
-          paste0(fileResultName, "-result.rds")
+          paste0(batchTaskId, "-result.rds")
         ))
 
+cat(paste0("Error Code: ", workerErrorStatus, fill = TRUE))
 quit(save = "yes",
-     status = 0,
+     status = workerErrorStatus,
      runLast = FALSE)

--- a/man/waitForTasksToComplete.Rd
+++ b/man/waitForTasksToComplete.Rd
@@ -4,7 +4,7 @@
 \alias{waitForTasksToComplete}
 \title{Wait for current tasks to complete}
 \usage{
-waitForTasksToComplete(jobId, timeout)
+waitForTasksToComplete(jobId, timeout, errorhandling = "stop")
 }
 \description{
 Wait for current tasks to complete


### PR DESCRIPTION
- Removed unneeded arguments with worker scripts (Use environment variables instead)
- Use job task counts
- Worker scripts throw errors

https://github.com/Azure/doAzureParallel/issues/36

**Output:**
Job Summary: 
Id: job20170915230023
Waiting for tasks to complete. . .
  |===========================================================                                                 |  55%
Errors have occurred while running the job 'job20170915230023'. Error handling is set to 'stop' and has proceeded to terminate the job. The user will have to handle deleting the job. If this is not the correct behavior, change the errorHandling property in the foreach object. Use the 'getJobFile' function to obtain the logs. For more information about getting job logs, follow this link: https://github.com/Azure/doAzureParallel/blob/master/docs/40-troubleshooting.md#viewing-files-directly-from-compute-nodeWarning message:
In waitForTasksToComplete(id, jobTimeout, obj$errorHandling) :
  There are currently 2 tasks failed while running the job:
job20170915230023-task5
job20170915230023-task6