### PR TITLE
Fix: Removed anaconda from path

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -38,7 +38,8 @@
 
   downloadCommand <-
     sprintf(
-      "/anaconda/envs/py35/bin/blobxfer %s %s %s --download --saskey $BLOBXFER_SASKEY --remoteresource . --include result/*.rds",
+      paste("/anaconda/envs/py35/bin/blobxfer %s %s %s --download --saskey $BLOBXFER_SASKEY",
+            "--remoteresource . --include result/*.rds"),
       accountName,
       jobId,
       "$AZ_BATCH_TASK_WORKING_DIR"

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -38,7 +38,7 @@
 
   downloadCommand <-
     sprintf(
-      "env PATH=$PATH blobxfer %s %s %s --download --saskey $BLOBXFER_SASKEY --remoteresource . --include result/*.rds",
+      "/anaconda/envs/py35/bin/blobxfer %s %s %s --download --saskey $BLOBXFER_SASKEY --remoteresource . --include result/*.rds",
       accountName,
       jobId,
       "$AZ_BATCH_TASK_WORKING_DIR"
@@ -88,8 +88,7 @@
 
   outputFiles <- append(outputFiles, userOutputFiles)
   commands <-
-    c("export PATH=/anaconda/envs/py35/bin:$PATH",
-      downloadCommand,
+    c(downloadCommand,
       rCommand)
 
   commands <- linuxWrapCommands(commands)
@@ -169,8 +168,7 @@
   args <- list(...)
 
   commands <- c(
-    "export PATH=/anaconda/envs/py35/bin:$PATH",
-    "env PATH=$PATH pip install --no-dependencies blobxfer"
+    "/anaconda/envs/py35/bin/pip install --no-dependencies blobxfer"
   )
 
   if (!is.null(args$commandLine)) {

--- a/inst/startup/install_cran.R
+++ b/inst/startup/install_cran.R
@@ -9,7 +9,7 @@ status <- tryCatch({
     }
   }
 
-  return(0)
+  0
 },
 error = function(e) {
   cat(sprintf(
@@ -19,7 +19,7 @@ error = function(e) {
 
   # Install packages doesn't return a non-exit code.
   # Using '1' as the default non-exit code
-  return(1)
+  1
 })
 
 quit(save = "yes",


### PR DESCRIPTION
- Removed anaconda from path
- Issue with installing doAzureParallel due to libxml2 from anaconda incompatible for xml2 R package. 

More info: http://www.perfectlyrandom.org/2015/12/13/install-xml2-r-package-on-macos/

#114 