### PR TITLE
For BioConductor install, force remove MRO 3.3 prior to installing MRO 3.4

### DIFF
--- a/samples/package_management/bioc_setup.sh
+++ b/samples/package_management/bioc_setup.sh
@@ -1,3 +1,5 @@
+yum erase microsoft-r-open-mro-3.3* --assumeyes
+
 if [ ! -d "microsoft-r-open" ]; then
     # Download R
     wget https://mran.microsoft.com/install/mro/3.4.0/microsoft-r-open-3.4.0.tar.gz
@@ -10,7 +12,6 @@ if [ ! -d "microsoft-r-open" ]; then
 fi 
 
 # Update PATH on the node permanently
-export PATH=/usr/lib64/microsoft-r/3.4/lib64/R/bin:$PATH
 echo "export PATH=/usr/lib64/microsoft-r/3.4/lib64/R/bin:$PATH" >> /etc/environment
 
 # Install bioconductor

--- a/samples/package_management/bioc_setup.sh
+++ b/samples/package_management/bioc_setup.sh
@@ -10,6 +10,7 @@ if [ ! -d "microsoft-r-open" ]; then
 fi 
 
 # Update PATH on the node permanently
+export PATH=/usr/lib64/microsoft-r/3.4/lib64/R/bin:$PATH
 echo "export PATH=/usr/lib64/microsoft-r/3.4/lib64/R/bin:$PATH" >> /etc/environment
 
 # Install bioconductor


### PR DESCRIPTION
The fix is to remove the MRO 3.3 _before_ installing MRO 3.4 so that MRO 3.4 install registers 3.4 as the default version of R to run. After this point, all tasks against the system will use it as the main runtime.