### PR TITLE
Enabling doParallel on the merge task

### DIFF
--- a/inst/startup/merger.R
+++ b/inst/startup/merger.R
@@ -49,7 +49,7 @@ if (typeof(cloudCombine) == "list" && enableCloudCombine) {
   }
 
   sessionInfo()
-  cluster <- parallel::makeCluster(parallel::detectCores(), outfile = "test.txt")
+  cluster <- parallel::makeCluster(parallel::detectCores(), outfile = "doParallel.txt")
   parallel::clusterExport(cluster, "libPaths")
   parallel::clusterEvalQ(cluster, .libPaths(libPaths))
 
@@ -145,9 +145,7 @@ if (typeof(cloudCombine) == "list" && enableCloudCombine) {
   })
 
   parallel::stopCluster(cluster)
-  }
 }
-
 
 quit(save = "yes",
      status = status,

--- a/inst/startup/merger.R
+++ b/inst/startup/merger.R
@@ -86,40 +86,24 @@ if (typeof(cloudCombine) == "list" && enableCloudCombine) {
           "result",
           paste0(batchJobId, "-task", i, "-result.rds")
         )
+      
+      task <- tryCatch({
+        readRDS(taskFileName)
+      }, error = function(e) {
+        e  
+      })
 
-      if (file.exists(taskFileName)) {
-        task <- readRDS(taskFileName)
-      }
-      else {
-        if (errorHandling == "stop") {
-          stop("Error found: ", task)
-        }
-        else if (errorHandling == "pass") {
-          for (t in 1:length(chunkSize)) {
-            result[[count]] <- NA
-            count <- count + 1
-          }
-
-          next
-        }
-        else if (errorHandling == "remove") {
-          next
-        }
-        else {
-          stop("Unknown error handling: ", errorHandling)
-        }
-      }
-
-      result <- vector("list", length(chunkSize))
       if (isError(task)) {
         if (errorHandling == "stop") {
           stop("Error found: ", task)
         }
         else if (errorHandling == "pass") {
+          result <- vector("list", length(chunkSize))
           for (t in 1:length(chunkSize)) {
             result[[t]] <- NA
           }
 
+          result
           next
         }
         else if (errorHandling == "remove"){
@@ -132,13 +116,8 @@ if (typeof(cloudCombine) == "list" && enableCloudCombine) {
 
       result <- vector("list", length(task))
       for (t in 1:length(task) ) {
-        if (isError(task[[t]]) && errorHandling != "pass") {
-          if (errorHandling == "remove") {
-            result[[t]] <- task[[t]]
-          }
-          else if (errorHandling == "stop") {
-            stop("Error found: ", task[[t]])
-          }
+        if (isError(task[[t]]) && errorHandling == "stop") {
+          stop("Error found: ", task[[t]])
         }
         else {
           result[[t]] <- task[[t]]

--- a/inst/startup/merger.R
+++ b/inst/startup/merger.R
@@ -100,7 +100,11 @@ if (typeof(cloudCombine) == "list" && enableCloudCombine) {
       ))
     }
     else if (errorHandling == "pass") {
-      results <- foreach::foreach(i = 1:batchTasksCount, .export = c("results", "count", "batchTasksCount", "chunkSize")) %dopar% {
+      results <- foreach::foreach(i = 1:batchTasksCount,
+                                  .export = c("results",
+                                              "count",
+                                              "batchTasksCount",
+                                              "chunkSize")) %dopar% {
         taskResult <-
           file.path(
             batchTaskWorkingDirectory,

--- a/inst/startup/merger.R
+++ b/inst/startup/merger.R
@@ -86,11 +86,10 @@ if (typeof(cloudCombine) == "list" && enableCloudCombine) {
           "result",
           paste0(batchJobId, "-task", i, "-result.rds")
         )
-      
       task <- tryCatch({
         readRDS(taskFileName)
       }, error = function(e) {
-        e  
+        e
       })
 
       if (isError(task)) {
@@ -115,7 +114,7 @@ if (typeof(cloudCombine) == "list" && enableCloudCombine) {
       }
 
       result <- vector("list", length(task))
-      for (t in 1:length(task) ) {
+      for (t in 1:length(task)) {
         if (isError(task[[t]]) && errorHandling == "stop") {
           stop("Error found: ", task[[t]])
         }

--- a/tests/testthat/test-error-handling.R
+++ b/tests/testthat/test-error-handling.R
@@ -1,5 +1,5 @@
 context("error handling test")
-test_that("Pass error handling test", {
+test_that("Remove error handling test", {
   testthat::skip("Live test")
   testthat::skip_on_travis()
   credentialsFileName <- "credentials.json"

--- a/tests/testthat/test-error-handling.R
+++ b/tests/testthat/test-error-handling.R
@@ -1,0 +1,59 @@
+context("error handling test")
+test_that("Pass error handling test", {
+  testthat::skip("Live test")
+  testthat::skip_on_travis()
+  credentialsFileName <- "credentials.json"
+  clusterFileName <- "cluster.json"
+
+  doAzureParallel::generateCredentialsConfig(credentialsFileName)
+  doAzureParallel::generateClusterConfig(clusterFileName)
+
+  # set your credentials
+  doAzureParallel::setCredentials(credentialsFileName)
+  cluster <- doAzureParallel::makeCluster(clusterFileName)
+  doAzureParallel::registerDoAzureParallel(cluster)
+
+  '%dopar%' <- foreach::'%dopar%'
+  res <-
+    foreach::foreach(i = 1:4, .errorhandling = "remove") %dopar% {
+      if (i == 3 || i == 4) {
+        randomObject
+      }
+
+      i
+    }
+
+  res
+
+  testthat::expect_equal(length(res), 2)
+})
+
+test_that("Pass error handling test", {
+  testthat::skip("Live test")
+  testthat::skip_on_travis()
+  credentialsFileName <- "credentials.json"
+  clusterFileName <- "cluster.json"
+
+  doAzureParallel::generateCredentialsConfig(credentialsFileName)
+  doAzureParallel::generateClusterConfig(clusterFileName)
+
+  # set your credentials
+  doAzureParallel::setCredentials(credentialsFileName)
+  cluster <- doAzureParallel::makeCluster(clusterFileName)
+  doAzureParallel::registerDoAzureParallel(cluster)
+
+  '%dopar%' <- foreach::'%dopar%'
+  res <-
+    foreach::foreach(i = 1:4, .errorhandling = "pass") %dopar% {
+      if (i == 2) {
+        randomObject
+      }
+
+      i
+    }
+
+  res
+
+  testthat::expect_equal(length(res), 4)
+  testthat::expect_true(class(res[[2]])[1] == "simpleError")
+})


### PR DESCRIPTION
This will increase the performance of the merge task by enabling the merge task to use all of its cores available.

- Added tests for error handling that were missing