### PR TITLE
allow local RProfile libraries to be loaded by default

### DIFF
--- a/R/doAzureParallel.R
+++ b/R/doAzureParallel.R
@@ -545,7 +545,7 @@ setHttpTraffic <- function(value = FALSE) {
       jobId = id,
       taskId = taskId,
       rCommand =  sprintf(
-        "Rscript --vanilla --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/worker.R %i %i %i > $AZ_BATCH_TASK_ID.txt",
+        "Rscript --no-save --no-environ --no-restore --no-site-file --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/worker.R %i %i %i > $AZ_BATCH_TASK_ID.txt",
         startIndex,
         endIndex,
         isDataSet),
@@ -568,7 +568,7 @@ setHttpTraffic <- function(value = FALSE) {
       jobId = id,
       taskId = "merge",
       rCommand = sprintf(
-        "Rscript --vanilla --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/merger.R %s %s %s > $AZ_BATCH_TASK_ID.txt",
+        "Rscript --no-save --no-environ --no-restore --no-site-file --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/merger.R %s %s %s > $AZ_BATCH_TASK_ID.txt",
         length(tasks),
         chunkSize,
         as.character(obj$errorHandling)

--- a/R/doAzureParallel.R
+++ b/R/doAzureParallel.R
@@ -545,7 +545,8 @@ setHttpTraffic <- function(value = FALSE) {
       jobId = id,
       taskId = taskId,
       rCommand =  sprintf(
-        "Rscript --no-save --no-environ --no-restore --no-site-file --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/worker.R %i %i %i > $AZ_BATCH_TASK_ID.txt",
+        paste("Rscript --no-save --no-environ --no-restore --no-site-file",
+        "--verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/worker.R %i %i %i > $AZ_BATCH_TASK_ID.txt"),
         startIndex,
         endIndex,
         isDataSet),
@@ -568,7 +569,8 @@ setHttpTraffic <- function(value = FALSE) {
       jobId = id,
       taskId = "merge",
       rCommand = sprintf(
-        "Rscript --no-save --no-environ --no-restore --no-site-file --verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/merger.R %s %s %s > $AZ_BATCH_TASK_ID.txt",
+        paste("Rscript --no-save --no-environ --no-restore --no-site-file",
+        "--verbose $AZ_BATCH_JOB_PREP_WORKING_DIR/merger.R %s %s %s > $AZ_BATCH_TASK_ID.txt"),
         length(tasks),
         chunkSize,
         as.character(obj$errorHandling)


### PR DESCRIPTION
In some cases, packages are available in libPaths defined by the .RProfile under ~/.RProfile. Running --vanilla implies the --no-init-file which tells the R runtime not to look at this file and load the paths. In some cases this leads to a mismatch between what happens at package install time and what is available at run time. The reason is that at package install time, we do not use ignore the profile and check if the packages are installed (which will return true) and therefore we do not install the package again. At run time though, these packages are not loaded and therefore can cause errors.