### PR TITLE
Upgraded description for fix resize cluster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,5 @@ Suggests:
     caret,
     plyr,
     lintr
-Remotes: Azure/rAzureBatch@v0.5.5
+Remotes: Azure/rAzureBatch@v0.5.6
 RoxygenNote: 6.0.1


### PR DESCRIPTION
#215 

Using enable autoscale formula instead of evaluate. This will update the formula on demand. 