### PR TITLE
Bugfix: Don't break when fetching batch-insights

### DIFF
--- a/inst/startup/cluster_setup.sh
+++ b/inst/startup/cluster_setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-wget https://github.com/Azure/batch-insights/releases/download/go-beta.1/batch-insight
+wget https://github.com/Azure/batch-insights/releases/download/go-beta.1/batch-insights
 chmod +x batch-insights
 ./batch-insights > node-stats.log &


### PR DESCRIPTION
Spell batch-insights correctly when fetching file. The bug causes pools orchestrated by doAzureParallel to fail with error TS_STATUS_TVM_STARTUP_TASK_FAILED (and all jobs running in these pools to fail).